### PR TITLE
Feature/service requests cycle

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -6,6 +6,7 @@ import { SellerLayoutComponent } from './layouts/seller-layout/seller-layout.com
 import { sellerRoutes } from './features/seller/seller.routes';
 import { ProductCardComponent } from './features/Home/product-card/product-card.component';
 import { ProductDetailsComponent } from './features/ProductDetails/product-details/product-details.component';
+import { ServiceRequestDetailsComponent } from './features/profile/service-request-details.component';
 
 export const routes: Routes = [
   {
@@ -56,6 +57,9 @@ export const routes: Routes = [
       import('./features/profile/profile.component').then(
         (m) => m.ProfileComponent
       ),
+    children: [
+      { path: 'requests/:id', component: ServiceRequestDetailsComponent }
+    ]
   },
   // Admin
   {

--- a/src/app/core/models/service-models/service-request-update.dto.ts
+++ b/src/app/core/models/service-models/service-request-update.dto.ts
@@ -1,0 +1,10 @@
+export interface ServiceRequestUpdateDto {
+  id: number;
+  totalOldPrice: number;
+  additionalPrice: number;
+  additionalQuantity: number;
+  additionalTime?: string;
+  additionalNote?: string;
+  status: string;
+  createdAt?: Date;
+}

--- a/src/app/core/models/service-models/service-request.dto.ts
+++ b/src/app/core/models/service-models/service-request.dto.ts
@@ -1,5 +1,6 @@
 export interface ServiceRequestDto {
   serviceId: number;
+  serviceTitle: string;
   requestedQuantity: number;
   requestDescription: string;
   pricePerProduct?: number;
@@ -9,4 +10,8 @@ export interface ServiceRequestDto {
   buyerApprovalStatus?: string;
   serviceStatus?: string;
   paymentStatus?: string;
+  sellerId?: string;
+  sellerName?: string;
+  imageUrl?: string;
+  sellerOfferAttempts:number;
 }

--- a/src/app/core/services/service-request-update.service.ts
+++ b/src/app/core/services/service-request-update.service.ts
@@ -1,0 +1,32 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ServiceRequestUpdateService {
+
+  private baseUrl = 'http://localhost:5250/api/ServiceRequestUpdate';
+  constructor(private http:HttpClient) { }
+
+  createUpdate(requestId: number, body: any) {
+    return this.http.post(`${this.baseUrl}/${requestId}`, body);
+  }
+
+  getUpdateById(id: number) {
+    return this.http.get(`${this.baseUrl}/${id}`);
+  }
+
+  getUpdatesByRequestId(requestId: number) {
+    return this.http.get(`${this.baseUrl}/request/${requestId}`);
+  }
+
+  cancelUpdate(id: number) {
+    return this.http.patch(`${this.baseUrl}/${id}/cancel`, {});
+  }
+
+  approveUpdate(id: number, approve:boolean) {
+    return this.http.patch(`${this.baseUrl}/seller-approval/${id}`, {approved: approve});
+  }
+
+}

--- a/src/app/core/services/service-request.service.ts
+++ b/src/app/core/services/service-request.service.ts
@@ -38,10 +38,14 @@ export class ServiceRequestService {
   }
 
   updateRequestStatus(requestId: number, status: string): Observable<any> {
-    return this.http.patch(`${this.baseUrl}/${requestId}/status/update`, { status });
+    return this.http.patch(`${this.baseUrl}/${requestId}/status/update`, { status:status });
   }
 
   getServiceIdsWithPendingRequests(): Observable<number[]> {
     return this.http.get<number[]>(`${this.baseUrl}/buyer/pending-services`);
+  }
+
+  cancelRequest(requestId: number): Observable<any> {
+    return this.http.patch(`${this.baseUrl}/${requestId}/buyer-cancel`, {});
   }
 }

--- a/src/app/features/profile/profile.component.html
+++ b/src/app/features/profile/profile.component.html
@@ -19,6 +19,10 @@
       <i class="pi pi-id-card text-xl"></i>
       Docs Verification
     </button>
+    <button (click)="switchTab('requests')" [ngClass]="{'bg-primary text-white': activeTab === 'requests', 'bg-white text-gray-700': activeTab !== 'requests'}" class="flex items-center gap-3 px-4 py-3 rounded-lg font-semibold transition-colors">
+      <i class="pi pi-list text-xl"></i>
+      My Service Requests
+    </button>
   </div>
   <!-- Main Content -->
   <div class="flex-1 flex flex-col items-center justify-start p-4 lg:p-12 min-h-screen w-full">
@@ -277,6 +281,83 @@
         <div class="flex justify-center mt-8">
           <button pButton type="button" label="Deactivate Account" class="bg-gray-700 text-white px-8 py-2 rounded-lg font-semibold shadow-md hover:bg-gray-900 transition-colors" (click)="deactivateUser()" [loading]="deactivateLoading" [disabled]="deactivateLoading"></button>
         </div>
+      </div>
+      <div *ngIf="activeTab === 'requests'">
+        <ng-container *ngIf="!buyerRequestDetailsId; else detailsView">
+          <div class="bg-white rounded-2xl shadow-lg p-6">
+            <h2 class="text-xl font-bold mb-4 text-pink-700">My Service Requests</h2>
+            <!-- Search and Filter Controls -->
+            <div class="flex flex-col md:flex-row md:items-center gap-4 mb-4">
+              <input pInputText type="text" [(ngModel)]="searchTerm" placeholder="Search by service or seller..." class="w-full md:w-64 border-pink-200" (ngModelChange)="filterRequests()" />
+              <select [(ngModel)]="statusFilter" (change)="filterRequests()" class="w-full md:w-48 border-pink-200 rounded px-2 py-2">
+                <option value="">All Statuses</option>
+                <option value="Pending">Pending</option>
+                <option value="Approved">Approved</option>
+                <option value="Rejected">Rejected</option>
+              </select>
+            </div>
+            <div *ngIf="buyerRequestsLoading" class="text-center py-8">
+              <i class="pi pi-spin pi-spinner text-2xl"></i> Loading...
+            </div>
+            <div *ngIf="!buyerRequestsLoading && buyerRequests.length === 0" class="text-center text-gray-500 py-8">
+              No service requests found.
+            </div>
+            <div *ngIf="!buyerRequestsLoading && buyerRequests.length > 0" class="overflow-x-auto rounded-2xl border border-pink-100 shadow-lg w-full bg-gradient-to-br from-pink-50 to-white">
+              <table class="bg-white rounded-xl overflow-hidden text-xs md:text-sm min-w-[500px] md:min-w-0 w-full">
+                <thead class="bg-pink-100 text-pink-700 sticky top-0 z-10">
+                  <tr>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Service</th>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Quantity</th>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Seller Offer</th>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Estimated Time</th>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Total Price</th>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Status</th>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Buyer Status</th>
+                    <th class="px-2 py-3 text-left font-bold whitespace-nowrap tracking-wide">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr *ngFor="let req of filteredRequests" class="border-b last:border-b-0 hover:bg-pink-50/80 transition group">
+                    <td class="px-2 py-2 font-semibold max-w-[100px] truncate text-pink-800 group-hover:text-pink-900" title="{{ req.serviceTitle }}">{{ req.serviceTitle }}</td>
+                    <td class="px-2 py-2 text-gray-700">{{ req.requestedQuantity }}</td>
+                    <td class="px-2 py-2">
+                      <span *ngIf="req.pricePerProduct != null && req.pricePerProduct !== 0; else noOffer" class="text-green-700 font-semibold">${{ req.pricePerProduct }}</span>
+                      <ng-template #noOffer><span class="text-gray-400 italic">Not set</span></ng-template>
+                    </td>
+                    <td class="px-2 py-2 text-gray-700">
+                      <span *ngIf="req.estimatedTime; else noTime">{{ req.estimatedTime }}</span>
+                      <ng-template #noTime><span class="text-gray-400 italic">Not set</span></ng-template>
+                    </td>
+                    <td class="px-2 py-2">
+                      <span *ngIf="req.totalPrice; else noTotal" class="text-pink-700 font-semibold">{{ req.totalPrice }}$</span>
+                      <ng-template #noTotal><span class="text-gray-400 italic">Not set</span></ng-template>
+                    </td>
+                    <td class="px-2 py-2">
+                      <span [ngClass]="{
+                        'bg-yellow-100 text-yellow-800 px-2 py-1 rounded text-xs font-bold': req.serviceStatus === 'Pending',
+                        'bg-green-100 text-green-800 px-2 py-1 rounded text-xs font-bold': req.serviceStatus === 'Approved',
+                        'bg-red-100 text-red-800 px-2 py-1 rounded text-xs font-bold': req.serviceStatus === 'Rejected'
+                      }">{{ req.serviceStatus }}</span>
+                    </td>
+                    <td class="px-2 py-2">
+                      <span [ngClass]="{
+                        'bg-yellow-100 text-yellow-800 px-2 py-1 rounded text-xs font-bold': req.buyerApprovalStatus === 'Pending',
+                        'bg-green-100 text-green-800 px-2 py-1 rounded text-xs font-bold': req.buyerApprovalStatus === 'Approved',
+                        'bg-red-100 text-red-800 px-2 py-1 rounded text-xs font-bold': req.buyerApprovalStatus === 'Rejected'
+                      }">{{ req.buyerApprovalStatus || 'Pending' }}</span>
+                    </td>
+                    <td class="px-2 py-2">
+                      <button pButton label="View Details" class="p-button-sm bg-pink-600 text-white px-3 py-1 rounded-lg font-semibold shadow-md hover:bg-pink-700 border-none transition" (click)="showRequestDetails(req.id)"></button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </ng-container>
+        <ng-template #detailsView>
+          <app-service-request-details [requestId]="buyerRequestDetailsId" (back)="buyerRequestDetailsId = 0"></app-service-request-details>
+        </ng-template>
       </div>
     </div>
   </div>

--- a/src/app/features/profile/service-request-details.component.html
+++ b/src/app/features/profile/service-request-details.component.html
@@ -1,0 +1,112 @@
+<div *ngIf="loading" class="text-center py-8">
+  <i class="pi pi-spin pi-spinner text-2xl"></i> Loading...
+</div>
+<div *ngIf="!loading && request">
+  <div class="flex flex-col md:flex-row gap-8 items-start mb-8 bg-white rounded-2xl shadow-xl p-6 border border-pink-100 overflow-x-auto md:overflow-x-visible">
+    <div *ngIf="request.imageUrl" class="flex-shrink-0 flex justify-center w-full md:w-auto">
+      <img [src]="request.imageUrl" alt="Service Image" class="w-48 h-48 object-cover rounded-2xl shadow-lg border-4 border-pink-100" />
+    </div>
+    <div class="flex-1 w-full min-w-0">
+      <h2 class="text-3xl font-bold mb-2 text-pink-700">
+        <a *ngIf="request.serviceId" [routerLink]="['/services', request.serviceId]" class="hover:underline hover:text-pink-900 transition-colors">
+          {{ request.serviceTitle }}
+        </a>
+        <span *ngIf="!request.serviceId">{{ request.serviceTitle }}</span>
+      </h2>
+      <div class="text-gray-600 mb-4 italic">{{ request.requestDescription }}</div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-2">
+        <div class="mb-2"><b>Quantity:</b> {{ request.requestedQuantity }}</div>
+        <div class="mb-2"><b>Status:</b> <span class="font-semibold" [ngClass]="{
+          'text-yellow-700': request.serviceStatus === 'Pending',
+          'text-blue-700': request.serviceStatus === 'InProgress',
+          'text-green-700': request.serviceStatus === 'Delivered',
+          'text-red-700': request.serviceStatus === 'Cancelled',
+          'text-gray-700': !['Pending','InProgress','Delivered','Cancelled'].includes(request.serviceStatus)
+        }"> {{ request.serviceStatus }}</span></div>
+        <div class="mb-2"><b>Seller:</b> <span class="font-semibold text-pink-700">
+          <a *ngIf="request.sellerId" [routerLink]="['/profile', request.sellerId]" class="hover:underline hover:text-pink-900 transition-colors">
+            {{ request.sellerName || 'N/A' }}
+          </a>
+          <span *ngIf="!request.sellerId">{{ request.sellerName || 'N/A' }}</span>
+        </span></div>
+        <div class="mb-2"><b>Seller Offer:</b> <span *ngIf="request.pricePerProduct != null && request.pricePerProduct !== 0; else noOffer"> ${{ request.pricePerProduct }}</span><ng-template #noOffer><span class="text-gray-400 italic"> Not set yet</span></ng-template></div>
+        <div class="mb-2"><b>Estimated Time:</b> <span *ngIf="request.estimatedTime; else noTime"> {{ request.estimatedTime }}</span><ng-template #noTime><span class="text-gray-400 italic"> Not set yet</span></ng-template></div>
+        <div class="mb-2"><b>Total Price:</b> <span *ngIf="request.totalPrice; else noTotal"> {{ request.totalPrice }}$</span><ng-template #noTotal><span class="text-gray-400 italic"> Not set yet</span></ng-template></div>
+        <div class="mb-2"><b>Buyer Status:</b> <span class="font-semibold" [ngClass]="{
+          'text-yellow-700': request.buyerApprovalStatus === 'Pending',
+          'text-green-700': request.buyerApprovalStatus === 'Approved',
+          'text-red-700': request.buyerApprovalStatus === 'Rejected'
+        }"> {{ request.buyerApprovalStatus || 'Pending' }}</span></div>
+      </div>
+      <div *ngIf="request.buyerApprovalStatus === 'Approved' && !hasPendingUpdate && request.serviceStatus === 'Pending'" class="mt-8">
+        <div class="flex justify-end mb-2">
+          <button pButton label="Request Update" class="p-button mb-2 bg-pink-600 border-pink-600 hover:bg-pink-700 hover:border-pink-700 text-white" (click)="openUpdateModal()"></button>
+        </div>
+
+        <!-- Modal for update creation -->
+        <p-dialog header="Create Update Request" [(visible)]="updateModalVisible" [modal]="true" [closable]="true" [dismissableMask]="true" [style]="{width: '400px'}">
+          <form [formGroup]="updateForm" (ngSubmit)="submitUpdate()" class="space-y-4">
+            <div>
+              <label class="block mb-1">Additional Price</label>
+              <input pInputText type="number" formControlName="additionalPrice" class="w-full" />
+            </div>
+            <div>
+              <label class="block mb-1">Additional Quantity</label>
+              <input pInputText type="number" formControlName="additionalQuantity" class="w-full" />
+            </div>
+            <div>
+              <label class="block mb-1">Additional Time</label>
+              <input pInputText type="text" formControlName="additionalTime" class="w-full" />
+            </div>
+            <div>
+              <label class="block mb-1">Additional Note</label>
+              <textarea pInputTextarea formControlName="additionalNote" class="w-full" rows="2"></textarea>
+            </div>
+            <div *ngIf="updateError" class="text-red-500 text-sm">{{ updateError }}</div>
+            <div *ngIf="updateSuccess" class="text-green-600 text-sm">{{ updateSuccess }}</div>
+            <button pButton type="submit" label="Send Update Request" class="p-button-info w-full" [disabled]="updateLoading"></button>
+          </form>
+        </p-dialog>
+      </div>
+      <div *ngIf="request.pricePerProduct && request.estimatedTime && request.buyerApprovalStatus === 'Pending'" class="mt-8">
+        <div class="flex gap-4 justify-end">
+          <button pButton label="Accept Offer" class="p-button-success bg-green-600 border-green-600 hover:bg-green-700 hover:border-green-700 text-white" (click)="acceptSellerOffer(request)"></button>
+          <button pButton label="Reject Offer" class="p-button-danger bg-red-600 border-red-600 hover:bg-red-700 hover:border-red-700 text-white" (click)="rejectSellerOffer(request)"></button>
+        </div>
+      </div>
+      <div *ngIf="isNegotiationClosed()" class="mt-4 p-4 bg-red-50 border border-red-200 rounded text-red-700 font-semibold text-center">
+        Negotiation closed. You rejected 3 offers from this seller.
+      </div>
+    </div>
+  </div>
+  <button pButton label="Back to Requests" class="p-button-secondary mb-6" (click)="goBack()"></button>
+
+  <div *ngIf="updates.length > 0" class="mt-12 w-full">
+    <h3 class="text-2xl font-bold mb-6 text-pink-700 flex items-center gap-2">
+      <i class="pi pi-history text-xl"></i> Update History
+    </h3>
+    <div class="grid gap-6">
+      <div *ngFor="let update of updates" class="bg-white border-l-8 border-pink-400 rounded-xl shadow-md p-6 flex flex-col gap-3 hover:shadow-xl transition-shadow max-w-3xl ml-0 mr-auto">
+        <div class="flex flex-wrap gap-6 items-center mb-2">
+          <div *ngIf="update.additionalPrice" class="text-pink-700 font-semibold"><i class="pi pi-dollar mr-1"></i>+{{ update.additionalPrice }}$</div>
+          <div *ngIf="update.additionalQuantity" class="text-blue-700 font-semibold"><i class="pi pi-box mr-1"></i>+{{ update.additionalQuantity }}</div>
+          <div *ngIf="update.additionalTime" class="text-purple-700 font-semibold"><i class="pi pi-clock mr-1"></i>{{ update.additionalTime }}</div>
+        </div>
+        <div *ngIf="update.additionalNote" class="italic text-gray-700 bg-pink-50 rounded p-2 border-l-4 border-pink-300"><i class="pi pi-comment mr-1"></i>{{ update.additionalNote }}</div>
+        <div class="flex justify-between items-center mt-2">
+          <span class="text-xs text-gray-500"><i class="pi pi-calendar mr-1"></i>Created: {{ update.createdAt | date:'medium' }}</span>
+          <span class="text-xs font-bold mx-2 px-3 py-1 rounded-full"
+            [ngClass]="{
+              'bg-yellow-100 text-yellow-800': update.status === 'Pending',
+              'bg-blue-100 text-blue-800': update.status === 'InProgress',
+              'bg-green-100 text-green-800': update.status === 'Delivered',
+              'bg-red-100 text-red-800': update.status === 'Cancelled',
+              'bg-gray-100 text-gray-800': !['Pending','InProgress','Delivered','Cancelled'].includes(update.status)
+            }">
+            {{ update.status }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/features/profile/service-request-details.component.ts
+++ b/src/app/features/profile/service-request-details.component.ts
@@ -1,0 +1,191 @@
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ServiceRequestService } from '../../core/services/service-request.service';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { ServiceRequestUpdateService } from '../../core/services/service-request-update.service';
+import { MessageService } from 'primeng/api';
+import { DialogModule } from 'primeng/dialog';
+import { ButtonModule } from 'primeng/button';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-service-request-details',
+  standalone: true,
+  templateUrl: './service-request-details.component.html',
+  imports:[CommonModule, ReactiveFormsModule, DialogModule, ButtonModule, RouterModule]
+})
+export class ServiceRequestDetailsComponent implements OnInit {
+  @Input() requestId!: number;
+  @Output() back = new EventEmitter<void>();
+
+  request: any = null;
+  loading = true;
+  updateForm: FormGroup;
+  updateLoading = false;
+  updateError = '';
+  updateSuccess = '';
+  updateModalVisible = false;
+  updates: any[] = [];
+  hasPendingUpdate = false;
+
+  constructor(
+    private route: ActivatedRoute,
+    private messageService: MessageService,
+    private requestService: ServiceRequestService,
+    private requestUpdateService: ServiceRequestUpdateService,
+    private fb: FormBuilder
+  ) {
+    this.updateForm = this.fb.group({
+      additionalPrice: [null],
+      additionalQuantity: [null],
+      additionalTime: [''],
+      additionalNote: ['']
+    });
+  }
+
+  ngOnInit() {
+    const id = this.requestId;
+    if (id) {
+      this.requestService.getRequestById(+id).subscribe({
+        next: (data) => {
+          this.request = data;
+          this.loading = false;
+        },
+        error: () => {
+          this.loading = false;
+        }
+      });
+      this.requestUpdateService.getUpdatesByRequestId(+id).subscribe({
+        next: (data: any) => {
+          this.updates = data;
+          this.hasPendingUpdate = Array.isArray(data) && data.some((u: any) => u.status === 'Pending');
+        },
+        error: () => {
+          this.updates = [];
+          this.hasPendingUpdate = false;
+        }
+      });
+    }
+  }
+
+  canUpdate() {
+    const { additionalPrice, additionalQuantity, additionalTime } = this.updateForm.value;
+    return additionalPrice || additionalQuantity || additionalTime;
+  }
+
+  openUpdateModal() {
+    this.updateError = '';
+    this.updateSuccess = '';
+    this.updateForm.reset();
+    this.updateModalVisible = true;
+  }
+
+  closeUpdateModal() {
+    this.updateModalVisible = false;
+  }
+
+  submitUpdate() {
+    if (!this.canUpdate()) {
+      this.updateError = 'Please provide at least one field to update.';
+      return;
+    }
+    this.updateLoading = true;
+    this.updateError = '';
+    this.updateSuccess = '';
+    const payload = {
+      additionalPrice: this.updateForm.value.additionalPrice,
+      additionalQuantity: this.updateForm.value.additionalQuantity,
+      additionalTime: this.updateForm.value.additionalTime,
+      additionalNote: this.updateForm.value.additionalNote
+    };
+    this.requestUpdateService.createUpdate(this.request.id, payload).subscribe({
+      next: () => {
+        this.updateSuccess = 'Update request sent!';
+        this.updateLoading = false;
+        this.ngOnInit();
+        this.closeUpdateModal();
+      },
+      error: () => {
+        this.updateError = 'Failed to send update.';
+        this.updateLoading = false;
+      }
+    });
+  }
+
+  cancelRequest() {
+  this.updateLoading = true;
+  this.updateError = '';
+  this.updateSuccess = '';
+  this.requestService.cancelRequest(this.request.id).subscribe({
+    next: () => {
+      this.updateSuccess = 'Request cancelled successfully.';
+      this.request.serviceStatus = 'Cancelled'; // or update as per your backend response
+      this.updateLoading = false;
+    },
+    error: (err) => {
+      this.updateError = 'Failed to cancel request.';
+      this.updateLoading = false;
+    }
+  });
+
+}
+
+acceptSellerOffer(request: any) {
+    this.requestService.updateBuyerStatus(request.id, 'Approved').subscribe({
+      next: () => {
+        this.messageService.add({ severity: 'success', summary: 'Offer Accepted', detail: 'You have accepted the seller offer.' });
+        this.refreshRequest();
+      },
+      error: () => {
+        this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to accept offer.' });
+      }
+    });
+  }
+
+  rejectSellerOffer(request: any) {
+    if (confirm('Are you sure you want to reject this offer?')) {
+      this.requestService.updateBuyerStatus(request.id, 'Rejected').subscribe({
+        next: () => {
+          this.messageService.add({ severity: 'success', summary: 'Offer Rejected', detail: 'You have rejected the seller offer.' });
+          this.refreshRequest();
+        },
+        error: () => {
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to reject offer.' });
+        }
+      });
+    }
+  }
+
+  refreshRequest() {
+    if (!this.request?.id) return;
+    this.loading = true;
+    this.requestService.getRequestById(this.request.id).subscribe({
+      next: (data) => {
+        this.request = data;
+        this.loading = false;
+      },
+      error: () => {
+        this.loading = false;
+      }
+    });
+    this.requestUpdateService.getUpdatesByRequestId(this.request.id).subscribe({
+      next: (data: any) => {
+        this.updates = data;
+        this.hasPendingUpdate = Array.isArray(data) && data.some((u: any) => u.status === 'Pending');
+      },
+      error: () => {
+        this.updates = [];
+        this.hasPendingUpdate = false;
+      }
+    });
+  }
+
+  goBack() {
+    this.back.emit();
+  }
+
+  isNegotiationClosed(): boolean {
+    return this.request && typeof this.request.sellerOfferAttempts === 'number' && this.request.sellerOfferAttempts >= 3 && this.request.buyerApprovalStatus === 'Rejected';
+  }
+}

--- a/src/app/features/seller/services/seller-service-details-page/seller-service-details-page.component.html
+++ b/src/app/features/seller/services/seller-service-details-page/seller-service-details-page.component.html
@@ -17,15 +17,34 @@
       </div>
     </div>
     <h4 class="text-lg font-semibold mb-4 text-gray-800">Buyer Requests</h4>
-    <p-table [value]="requests" [paginator]="true" [rows]="5" *ngIf="requests && requests.length > 0" class="shadow rounded-xl">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
+      <div class="flex gap-2 items-center bg-white rounded shadow px-3 py-2 border border-gray-200">
+        <i class="pi pi-search text-gray-400 text-lg"></i>
+        <input pInputText type="text" [(ngModel)]="searchText" placeholder="Search by buyer name..." class="p-inputtext-sm w-64 border-0 focus:ring-0 outline-none" />
+      </div>
+      <div class="flex gap-4 items-center bg-white rounded shadow px-3 py-2 border border-gray-200">
+        <div class="flex gap-2 items-center">
+          <label class="font-medium text-gray-700">Status:</label>
+          <p-dropdown [options]="statusFilterOptions" [(ngModel)]="statusFilter" placeholder="All" [showClear]="true" class="p-dropdown-sm w-32"></p-dropdown>
+        </div>
+        <div class="flex gap-2 items-center">
+          <label class="font-medium text-gray-700">Approval:</label>
+          <p-dropdown [options]="approvalFilterOptions" [(ngModel)]="approvalFilter" placeholder="All" [showClear]="true" class="p-dropdown-sm w-32"></p-dropdown>
+        </div>
+      </div>
+    </div>
+    <p-table [value]="filteredRequests()" [paginator]="true" [rows]="5" *ngIf="filteredRequests().length > 0" class="shadow rounded-xl">
       <ng-template pTemplate="header">
         <tr>
           <th>Buyer</th>
           <th>Quantity</th>
           <th>Status</th>
+          <th>Buyer Approval</th>
           <th>Offer Price</th>
+          <th>Total Price</th>
           <th>Offer Time</th>
-          <th>Actions</th>
+          <th>Description</th>
+          <th class="text-center align-middle" style="vertical-align: middle; text-align: center;">Actions</th>
         </tr>
       </ng-template>
       <ng-template pTemplate="body" let-request>
@@ -40,18 +59,61 @@
             }">{{ request.serviceStatus }}</span>
           </td>
           <td>
+            <span [ngClass]="{
+              'bg-yellow-50 text-yellow-700 px-2 py-1 rounded text-xs': request.buyerApprovalStatus === 'Pending',
+              'bg-green-50 text-green-700 px-2 py-1 rounded text-xs': request.buyerApprovalStatus === 'Approved',
+              'bg-red-50 text-red-700 px-2 py-1 rounded text-xs': request.buyerApprovalStatus === 'Rejected'
+            }">{{ request.buyerApprovalStatus || 'N/A' }}</span>
+          </td>
+          <td>
             <span *ngIf="request.pricePerProduct != null && request.pricePerProduct !== 0; else notSet">{{ request.pricePerProduct }}</span>
             <ng-template #notSet><span class="text-gray-400 italic">Not set</span></ng-template>
+          </td>
+          <td>
+            <span *ngIf="request.pricePerProduct != null && request.pricePerProduct !== 0 && request.requestedQuantity != null && request.requestedQuantity !== 0; else notSetTotal">
+              {{ request.totalPrice | number:'1.2-2' }}
+            </span>
+            <ng-template #notSetTotal><span class="text-gray-400 italic">Not set</span></ng-template>
           </td>
           <td>
             <span *ngIf="request.estimatedTime; else notSetTime">{{ request.estimatedTime }}</span>
             <ng-template #notSetTime><span class="text-gray-400 italic">Not set</span></ng-template>
           </td>
           <td>
-            <button pButton label="Set Offer" class="p-button-sm p-button-success" (click)="openOfferModal(request)"
-              *ngIf="request.serviceStatus !== 'Approved'"
-              [disabled]="request.pricePerProduct != null && request.estimatedTime">
-            </button>
+            <button pButton type="button" icon="pi pi-info-circle" class="p-button-xs p-button-rounded p-button-info" (click)="openDescriptionModal(request)" pTooltip="View Description" tooltipPosition="top"></button>
+          </td>
+          <td class="text-center align-middle">
+            <div class="inline-flex flex-col md:flex-row md:items-center gap-2 justify-center">
+              <button pButton label="Set Offer" class="p-button-sm p-button-success" (click)="openOfferModal(request)"
+                [disabled]="!canSetOffer(request)"
+                [pTooltip]="getSetOfferTooltip(request)"
+                tooltipPosition="top">
+              </button>
+              <span class="relative inline-block">
+                <button pButton label="View Updates" class="p-button-sm p-button-info" (click)="openUpdatesModal(request)"
+                  [disabled]="request.buyerApprovalStatus !== 'Approved'"
+                  [pTooltip]="getViewUpdatesTooltip(request)"
+                  tooltipPosition="top">
+                </button>
+                <span *ngIf="getPendingUpdatesCount(request) > 0"
+                  class="absolute -top-2 -right-2 bg-red-500 text-white text-xs rounded-full px-1.5 py-0.5 border border-white shadow">
+                  {{ getPendingUpdatesCount(request) }}
+                </span>
+              </span>
+              <div class="flex items-center gap-1">
+                <p-dropdown [options]="requestStatusOptions"
+                  [(ngModel)]="request._newStatus"
+                  [style]="{width: '140px', minWidth: '120px', maxWidth: '180px'}"
+                  [autoDisplayFirst]="false"
+                  [showClear]="false"
+                  [disabled]="request.buyerApprovalStatus !== 'Approved'"
+                  [ngClass]="'p-dropdown-sm'"
+                  [appendTo]="'body'"
+                  placeholder="Change Status">
+                </p-dropdown>
+                <button pButton type="button" icon="pi pi-check" class="p-button-xs p-button-rounded p-button-primary" (click)="changeRequestStatus(request)" [disabled]="request._newStatus === request.serviceStatus || request.buyerApprovalStatus !== 'Approved'" pTooltip="Save Status" tooltipPosition="top"></button>
+              </div>
+            </div>
           </td>
         </tr>
       </ng-template>
@@ -85,6 +147,57 @@
     <div class="flex justify-end gap-2 mt-4">
       <button pButton type="button" label="Close" class="p-button-secondary" (click)="closeOfferModal()" [disabled]="offerLoading"></button>
       <button pButton type="button" label="Send Offer" class="p-button-success" (click)="submitOffer()" [disabled]="offerForm.invalid || offerLoading"></button>
+    </div>
+  </p-dialog>
+  <!-- Updates Modal -->
+  <p-dialog [(visible)]="updatesModalVisible" [modal]="true" [closable]="true" [style]="{width: '600px'}" (onHide)="closeUpdatesModal()">
+    <ng-template pTemplate="header">
+      <span>Request Updates</span>
+    </ng-template>
+    <div *ngIf="selectedUpdatesRequest">
+      <div class="font-semibold mb-2 text-pink-700 flex items-center gap-2">
+        <span>Updates for {{ selectedUpdatesRequest.buyerName }}</span>
+        <i *ngIf="selectedUpdatesRequest.updatesLoading" class="pi pi-spin pi-spinner text-pink-700"></i>
+      </div>
+      <div *ngIf="selectedUpdatesRequest.updatesLoading" class="text-pink-700">Loading updates...</div>
+      <div *ngIf="!selectedUpdatesRequest.updatesLoading && selectedUpdatesRequest.updates && selectedUpdatesRequest.updates.length > 0">
+        <div *ngFor="let update of selectedUpdatesRequest.updates" class="mb-2 p-3 rounded border border-pink-200 bg-white flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+          <div>
+            <span *ngIf="update.additionalPrice" class="text-pink-700 font-semibold mr-2">+${{ update.additionalPrice }}</span>
+            <span *ngIf="update.additionalQuantity" class="text-blue-700 font-semibold mr-2">+{{ update.additionalQuantity }}</span>
+            <span *ngIf="update.additionalTime" class="text-purple-700 font-semibold mr-2">{{ update.additionalTime }}</span>
+            <span *ngIf="update.additionalNote && update.additionalNote.trim() !== ''" class="block italic text-gray-700 bg-pink-50 rounded p-1 border-l-4 border-pink-300 mt-1">{{ update.additionalNote }}</span>
+          </div>
+          <div class="flex gap-2 items-center">
+            <span class="text-xs font-bold px-2 py-1 rounded-full"
+              [ngClass]="{
+                'bg-yellow-100 text-yellow-800': update.status === 'Pending',
+                'bg-green-100 text-green-800': update.status === 'Approved',
+                'bg-red-100 text-red-800': update.status === 'Rejected'
+              }">
+              {{ update.status }}
+            </span>
+            <button *ngIf="update.status === 'Pending'" pButton type="button" label="Accept" class="p-button-xs p-button-success" (click)="acceptUpdate(update)"></button>
+            <button *ngIf="update.status === 'Pending'" pButton type="button" label="Reject" class="p-button-xs p-button-danger" (click)="rejectUpdate(update)"></button>
+          </div>
+        </div>
+      </div>
+      <div *ngIf="!selectedUpdatesRequest.updatesLoading && (!selectedUpdatesRequest.updates || selectedUpdatesRequest.updates.length === 0)" class="text-gray-400 italic">No updates for this request.</div>
+    </div>
+    <div class="flex justify-end gap-2 mt-4">
+      <button pButton type="button" label="Close" class="p-button-secondary" (click)="closeUpdatesModal()"></button>
+    </div>
+  </p-dialog>
+  <!-- Description Modal -->
+  <p-dialog [(visible)]="descriptionModalVisible" [modal]="true" [closable]="true" [style]="{width: '400px'}" (onHide)="closeDescriptionModal()">
+    <ng-template pTemplate="header">
+      <span>Request Description</span>
+    </ng-template>
+    <div *ngIf="selectedDescriptionRequest">
+      <div class="mb-2 text-gray-700 whitespace-pre-line">{{ selectedDescriptionRequest.requestDescription || 'No description provided.' }}</div>
+    </div>
+    <div class="flex justify-end gap-2 mt-4">
+      <button pButton type="button" label="Close" class="p-button-secondary" (click)="closeDescriptionModal()"></button>
     </div>
   </p-dialog>
 </div>

--- a/src/app/features/seller/services/seller-service-details-page/seller-service-details-page.component.ts
+++ b/src/app/features/seller/services/seller-service-details-page/seller-service-details-page.component.ts
@@ -2,17 +2,21 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { ServiceService } from '../../../../core/services/service.service';
 import { ServiceRequestService } from '../../../../core/services/service-request.service';
+import { ServiceRequestUpdateService } from '../../../../core/services/service-request-update.service';
 import { CommonModule } from '@angular/common';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
 import { DialogModule } from 'primeng/dialog';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
+import { DropdownModule } from 'primeng/dropdown';
+import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'app-seller-service-details-page',
   templateUrl: './seller-service-details-page.component.html',
   standalone: true,
-  imports: [CommonModule, TableModule, ButtonModule, DialogModule, ReactiveFormsModule]
+  imports: [CommonModule, TableModule, ButtonModule, DialogModule, ReactiveFormsModule, FormsModule, DropdownModule, TooltipModule]
 })
 export class SellerServiceDetailsPageComponent implements OnInit {
   service: any = null;
@@ -25,10 +29,45 @@ export class SellerServiceDetailsPageComponent implements OnInit {
   offerError = '';
   offerSuccess = '';
 
+  // For status dropdown
+  requestStatusOptions = [
+    { label: 'Pending', value: 'Pending' },
+    { label: 'InProgress', value: 'InProgress' },
+    { label: 'Delivered', value: 'Delivered' },
+    { label: 'Cancelled', value: 'Cancelled' }
+  ];
+
+  // Updates modal state
+  updatesModalVisible = false;
+  selectedUpdatesRequest: any = null;
+
+  // Description modal state
+  descriptionModalVisible = false;
+  selectedDescriptionRequest: any = null;
+
+  // Search and filter state
+  searchText: string = '';
+  statusFilter: string | null = null;
+  approvalFilter: string | null = null;
+  statusFilterOptions = [
+    { label: 'All', value: null },
+    { label: 'Pending', value: 'Pending' },
+    { label: 'InProgress', value: 'InProgress' },
+    { label: 'Delivered', value: 'Delivered' },
+    { label: 'Cancelled', value: 'Cancelled' }
+  ];
+  approvalFilterOptions = [
+    { label: 'All', value: null },
+    { label: 'Pending', value: 'Pending' },
+    { label: 'Approved', value: 'Approved' },
+    { label: 'Rejected', value: 'Rejected' }
+  ];
+
   constructor(
     private route: ActivatedRoute,
     private serviceService: ServiceService,
     private serviceRequestService: ServiceRequestService,
+    private serviceRequestUpdateService: ServiceRequestUpdateService,
     private fb: FormBuilder
   ) {
     this.offerForm = this.fb.group({
@@ -48,17 +87,41 @@ export class SellerServiceDetailsPageComponent implements OnInit {
           this.service = null;
         }
       });
-      this.serviceRequestService.getSellerRequestsByServiceId(+id).subscribe({
-        next: (requests) => {
-          this.requests = requests;
-          this.loading = false;
-        },
-        error: () => {
-          this.requests = [];
-          this.loading = false;
-        }
-      });
+      this.fetchRequestsWithUpdates(+id);
     }
+  }
+
+  fetchRequestsWithUpdates(serviceId: number) {
+    this.serviceRequestService.getSellerRequestsByServiceId(serviceId).subscribe({
+      next: (requests) => {
+        this.requests = requests.map((req: any) => ({ ...req, _newStatus: req.serviceStatus }));
+        let pending = 0;
+        this.requests.forEach((req: any, idx: number) => {
+          if (req.buyerApprovalStatus === 'Approved') {
+            pending++;
+            this.serviceRequestUpdateService.getUpdatesByRequestId(req.id).subscribe({
+              next: (updates: any) => {
+                req.updates = updates;
+                pending--;
+                if (pending === 0) this.loading = false;
+              },
+              error: () => {
+                req.updates = [];
+                pending--;
+                if (pending === 0) this.loading = false;
+              }
+            });
+          } else {
+            req.updates = [];
+          }
+        });
+        if (pending === 0) this.loading = false;
+      },
+      error: () => {
+        this.requests = [];
+        this.loading = false;
+      }
+    });
   }
 
   openOfferModal(request: any) {
@@ -105,5 +168,137 @@ export class SellerServiceDetailsPageComponent implements OnInit {
         this.offerLoading = false;
       }
     });
+  }
+
+  acceptUpdate(update: any) {
+    this.serviceRequestUpdateService.approveUpdate(update.id, true).subscribe({
+      next: () => {
+        update.status = 'Approved';
+      },
+      error: () => {
+        // Optionally show error
+      }
+    });
+  }
+
+  rejectUpdate(update: any) {
+    this.serviceRequestUpdateService.approveUpdate(update.id, false).subscribe({
+      next: () => {
+        update.status = 'Rejected';
+      },
+      error: () => {
+        // Optionally show error
+      }
+    });
+  }
+
+  openUpdatesModal(request: any) {
+    this.selectedUpdatesRequest = request;
+    this.updatesModalVisible = true;
+    // Optionally, re-fetch updates here if you want to always show latest
+    // this.fetchUpdatesForRequest(request);
+  }
+
+  closeUpdatesModal() {
+    this.updatesModalVisible = false;
+    this.selectedUpdatesRequest = null;
+  }
+
+  openDescriptionModal(request: any) {
+    this.selectedDescriptionRequest = request;
+    this.descriptionModalVisible = true;
+  }
+
+  closeDescriptionModal() {
+    this.descriptionModalVisible = false;
+    this.selectedDescriptionRequest = null;
+  }
+
+  getPendingUpdatesCount(request: any): number {
+    if (!request.updates || !Array.isArray(request.updates)) return 0;
+    return request.updates.filter((u: any) => u.status === 'Pending').length;
+  }
+
+  changeRequestStatus(request: any) {
+    if (!request._newStatus || request._newStatus === request.serviceStatus) return;
+    this.serviceRequestService.updateRequestStatus(request.id, request._newStatus).subscribe({
+      next: () => {
+        request.serviceStatus = request._newStatus;
+      },
+      error: () => {
+        // Optionally show error
+        request._newStatus = request.serviceStatus;
+      }
+    });
+  }
+
+  getOfferAttemptsLeft(request: any): number {
+    return 3 - (typeof request.sellerOfferAttempts === 'number' ? request.sellerOfferAttempts : 0);
+  }
+
+  canSetOffer(request: any): boolean {
+    if (!request) return false;
+    const attempts = typeof request.sellerOfferAttempts === 'number' ? request.sellerOfferAttempts : 0;
+    if (request.serviceStatus === 'Cancelled') return false;
+    if (attempts >= 3) return false;
+    // Allow if buyer rejected and attempts left
+    if (request.buyerApprovalStatus === 'Rejected' && attempts < 3) return true;
+    // Allow if no offer yet and attempts left
+    if ((!request.pricePerProduct || !request.estimatedTime) && attempts < 3) return true;
+    // Allow if buyer has not yet responded and attempts left
+    if (request.buyerApprovalStatus === 'Pending' && attempts < 3) return true;
+    // Disallow if already approved
+    if (request.serviceStatus === 'Approved') return false;
+    return false;
+  }
+
+  getSetOfferTooltip(request: any): string {
+    const attempts = typeof request.sellerOfferAttempts === 'number' ? request.sellerOfferAttempts : 0;
+    if (request.serviceStatus !== 'Pending') {
+      return 'Cannot set offer: Service is not pending.';
+    }
+    if (attempts >= 3) {
+      return 'No more offer attempts allowed (max 3 reached).';
+    }
+    if (request.buyerApprovalStatus === 'Approved') {
+      return 'Buyer has approved your offer.';
+    }
+    if (request.buyerApprovalStatus === 'Rejected') {
+      return `Buyer rejected your last offer. Attempts left: ${3 - attempts}`;
+    }
+    if (request.buyerApprovalStatus === 'Pending') {
+      return `Waiting for buyer response. Attempts left: ${3 - attempts}`;
+    }
+    return `You can set an offer up to 3 times. Attempts left: ${3 - attempts}`;
+  }
+
+  getViewUpdatesTooltip(request: any): string {
+    if (!request.pricePerProduct || !request.estimatedTime) {
+      return 'Set an offer and wait for buyer approval before updates are available.';
+    }
+    if (request.buyerApprovalStatus !== 'Approved') {
+      return 'Updates are only available after buyer approves your offer.';
+    }
+    if (!request.updates || request.updates.length === 0) {
+      return 'No updates for this request yet.';
+    }
+    return 'View updates for this request.';
+  }
+
+  filteredRequests(): any[] {
+    let filtered = this.requests;
+    if (this.searchText && this.searchText.trim() !== '') {
+      const search = this.searchText.trim().toLowerCase();
+      filtered = filtered.filter(req =>
+        req.buyerName && req.buyerName.toLowerCase().includes(search)
+      );
+    }
+    if (this.statusFilter) {
+      filtered = filtered.filter(req => req.serviceStatus === this.statusFilter);
+    }
+    if (this.approvalFilter) {
+      filtered = filtered.filter(req => req.buyerApprovalStatus === this.approvalFilter);
+    }
+    return filtered;
   }
 }

--- a/src/app/features/service/service-details/service-details.component.html
+++ b/src/app/features/service/service-details/service-details.component.html
@@ -1,31 +1,45 @@
-<div class="p-6 max-w-3xl mx-auto">
-  <img
-    [src]="service?.imageUrl || 'https://via.placeholder.com/600x300?text=No+Image'"
-    class="w-full h-64 object-cover rounded-lg mb-6"
-    alt="Service Image"
-  />
+<div class="min-h-screen flex items-center justify-center bg-gray-50">
+  <div class="p-6 max-w-3xl w-full mx-auto bg-white rounded-2xl shadow-xl border border-blue-100">
+    <img
+      [src]="service?.imageUrl || 'https://via.placeholder.com/600x300?text=No+Image'"
+      class="w-full h-64 object-cover rounded-xl mb-6 border-4 border-blue-100 shadow-lg"
+      alt="Service Image"
+    />
 
-  <h1 class="text-3xl font-bold mb-2">{{ service?.name }}</h1>
-  <p class="text-gray-700 mb-4">{{ service?.description }}</p>
+    <h1 class="text-4xl font-extrabold mb-2 text-blue-700 flex items-center gap-2">
+      <i class="pi pi-briefcase text-2xl text-blue-400"></i> {{ service?.name }}
+    </h1>
+    <p class="text-gray-700 mb-6 text-lg leading-relaxed">{{ service?.description }}</p>
 
-  <ul class="text-gray-600 space-y-1 mb-6">
-    <li><strong>Price per product:</strong> ${{ service?.pricePerProduct }}</li>
-    <li><strong>Minimum Quantity:</strong> {{ service?.minQuantity }}</li>
-    <li><strong>Estimated Time:</strong> {{ service?.estimatedTime }}</li>
-    <li><strong>Seller:</strong> <span class="text-primary underline cursor-not-allowed opacity-70" title="Seller profile coming soon"> {{ service?.sellerName }}</span></li>
-  </ul>
+    <ul class="text-gray-600 space-y-2 mb-8 text-base">
+      <li><i class="pi pi-dollar text-blue-600 mr-1"></i><strong>Price per product:</strong> <span class="ml-2 text-blue-700 font-semibold">${{ service?.pricePerProduct }}</span></li>
+      <li><i class="pi pi-box text-blue-500 mr-1"></i><strong>Minimum Quantity:</strong> <span class="ml-2 font-semibold">{{ service?.minQuantity }}</span></li>
+      <li><i class="pi pi-clock text-blue-400 mr-1"></i><strong>Estimated Time:</strong> <span class="ml-2 font-semibold">{{ service?.estimatedTime }}</span></li>
+      <li><i class="pi pi-user text-blue-500 mr-1"></i><strong>Seller:</strong> <span class="ml-2 text-blue-700 underline cursor-not-allowed opacity-70" title="Seller profile coming soon">{{ service?.sellerName }}</span></li>
+    </ul>
 
-  <button
-    pButton
-    type="button"
-    label="Request Service"
-    class="p-button-success px-5 py-2 rounded-lg shadow-md"
-    [disabled]="hasPendingRequest"
-    (click)="openRequestModal()"
-  ></button>
-  <span *ngIf="hasPendingRequest" class="text-xs text-gray-600 block mt-2">
-    You already have a pending request for this service.
-  </span>
+    <div class="flex flex-col sm:flex-row gap-4 items-center">
+      <button
+        pButton
+        type="button"
+        label="Request Service"
+        class="p-button-success px-6 py-2 rounded-lg shadow-md text-lg font-semibold"
+        [disabled]="hasPendingRequest"
+        (click)="openRequestModal()"
+      ></button>
+      <span *ngIf="hasPendingRequest" class="text-xs text-gray-600 block mt-2 sm:mt-0">
+        <i class="pi pi-info-circle text-yellow-500 mr-1"></i> You already have a pending request for this service.
+      </span>
+    </div>
+
+    <button
+      pButton
+      type="button"
+      label="Back to All Services"
+      class="p-button-secondary mt-8 w-full sm:w-auto px-6 py-2 rounded-lg font-semibold"
+      (click)="goBackToServices()"
+    ></button>
+  </div>
 </div>
 
 <!-- Modal -->

--- a/src/app/features/service/service-details/service-details.component.ts
+++ b/src/app/features/service/service-details/service-details.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Service } from '../../../core/models/service-models/service.dto';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { ServiceService } from '../../../core/services/service.service';
 import { CommonModule } from '@angular/common';
 import { RequestModalComponent } from '../request-modal/request-modal.component';
@@ -22,7 +22,8 @@ export class ServiceDetailsComponent {
   constructor(
     private route: ActivatedRoute,
     private serviceService: ServiceService,
-    private requestService: ServiceRequestService
+    private requestService: ServiceRequestService,
+    private router: Router
   ) {}
 
   ngOnInit() {
@@ -43,5 +44,9 @@ export class ServiceDetailsComponent {
   onRequestSubmitted() {
     this.hasPendingRequest = true;
     this.isModalOpen = false;
+  }
+
+  goBackToServices() {
+    this.router.navigate(['/services']);
   }
 }

--- a/src/app/features/service/service-list/service-list.component.html
+++ b/src/app/features/service/service-list/service-list.component.html
@@ -1,50 +1,76 @@
 <!-- all-services.component.html -->
-<div class="p-8 bg-gray-50 min-h-screen">
-  <h2 class="text-3xl font-bold text-gray-800 mb-8 text-center">All Available Services</h2>
-  <div class="flex flex-col md:flex-row gap-4 mb-8 items-center justify-center">
-    <input
-      pInputText
-      type="text"
-      [(ngModel)]="searchTerm"
-      (ngModelChange)="onSearchOrFilter()"
-      placeholder="Search by service name..."
-      class="w-full md:w-64 border border-gray-300 rounded px-3 py-2"
-    />
-    <select
-      [(ngModel)]="sellerFilter"
-      (ngModelChange)="onSearchOrFilter()"
-      class="w-full md:w-48 border border-gray-300 rounded px-3 py-2"
-    >
-      <option value="">All Sellers</option>
-      <option *ngFor="let seller of sellerNames" [value]="seller">{{ seller }}</option>
-    </select>
-  </div>
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-    <p-card *ngFor="let service of filteredServices" class="mb-4">
-      <ng-template pTemplate="header">
-        <img
-          [src]="service.imageUrl || 'https://via.placeholder.com/400x200?text=No+Image'"
-          alt="Service Image"
-          class="rounded-lg w-full h-48 object-cover"
+<div class="p-8 bg-gradient-to-br from-gray-50 to-blue-100 min-h-screen">
+  <h2 class="text-4xl font-extrabold text-blue-700 mb-10 text-center tracking-tight drop-shadow-sm flex items-center justify-center gap-3">
+    <i class="pi pi-th-large text-3xl text-blue-400"></i> All Available Services
+  </h2>
+  <div class="flex flex-col lg:flex-row gap-10 max-w-7xl mx-auto lg:justify-center">
+    <!-- Sidebar for search/filter -->
+    <aside class="w-full lg:w-72 bg-white rounded-2xl shadow-xl p-8 mb-8 lg:mb-0 border border-blue-100 h-max flex-shrink-0">
+      <h3 class="text-xl font-bold text-blue-700 mb-6 flex items-center gap-2">
+        <i class="pi pi-filter text-blue-400"></i> Filter Services
+      </h3>
+      <div class="mb-6">
+        <label class="block text-gray-700 font-medium mb-2">Search</label>
+        <input
+          pInputText
+          type="text"
+          [(ngModel)]="searchTerm"
+          (ngModelChange)="onSearchOrFilter()"
+          placeholder="Service name..."
+          class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 transition"
         />
-      </ng-template>
-      <h3 class="text-xl font-semibold text-gray-800">{{ service.name }}</h3>
-      <p class="text-gray-600 text-sm truncate" [title]="service.description">
-        {{ service.description | slice:0:80 }}<span *ngIf="service.description.length > 80">...</span>
-      </p>
-      <p class="text-base font-medium text-blue-700 mt-2">Price: ${{ service.pricePerProduct }}</p>
-      <p class="text-sm mt-2">
-        Seller:
-        <span class="text-primary underline cursor-not-allowed opacity-70" title="Seller profile coming soon">
-          {{ service.sellerName }}
-        </span>
-      </p>
-      <a
-        [routerLink]="['/services', service.id]"
-        pButton
-        label="View Details"
-        class="mt-4 p-button-sm p-button-rounded p-button-info w-full"
-      ></a>
-    </p-card>
+      </div>
+      <div>
+        <label class="block text-gray-700 font-medium mb-2">Seller</label>
+        <select
+          [(ngModel)]="sellerFilter"
+          (ngModelChange)="onSearchOrFilter()"
+          class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:border-blue-400 focus:ring-2 focus:ring-blue-100 transition"
+        >
+          <option value="">All Sellers</option>
+          <option *ngFor="let seller of sellerNames" [value]="seller">{{ seller }}</option>
+        </select>
+      </div>
+    </aside>
+    <!-- Service cards -->
+    <main class="flex-1 lg:max-w-[calc(100%-20rem)]">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+        <p-card *ngFor="let service of filteredServices" class="mb-6 bg-white rounded-2xl shadow-lg border border-blue-100 hover:shadow-2xl transition-shadow">
+          <ng-template pTemplate="header">
+            <img
+              [src]="service.imageUrl || 'https://via.placeholder.com/400x200?text=No+Image'"
+              alt="Service Image"
+              class="rounded-xl w-full h-48 object-cover border-2 border-blue-100 shadow-sm"
+            />
+          </ng-template>
+          <h3 class="text-2xl font-bold text-blue-700 mb-1 flex items-center gap-2">
+            <i class="pi pi-briefcase text-blue-400"></i> {{ service.name }}
+          </h3>
+          <p class="text-gray-600 text-base truncate mb-2" [title]="service.description">
+            {{ service.description | slice:0:80 }}<span *ngIf="service.description.length > 80">...</span>
+          </p>
+          <div class="flex flex-wrap gap-3 mb-2">
+            <span class="text-green-700 font-semibold flex items-center">
+              <i class="pi pi-dollar mr-1"></i> ${{ service.pricePerProduct }}
+            </span>
+            <span class="text-blue-700 font-semibold flex items-center">
+              <i class="pi pi-box mr-1"></i> Min: {{ service.minQuantity }}
+            </span>
+          </div>
+          <p class="text-sm mb-2">
+            <i class="pi pi-user text-blue-400 mr-1"></i> Seller:
+            <span class="text-blue-700 underline cursor-not-allowed opacity-70" title="Seller profile coming soon">
+              {{ service.sellerName }}
+            </span>
+          </p>
+          <a
+            [routerLink]="['/services', service.id]"
+            pButton
+            label="View Details"
+            class="mt-4 p-button-sm p-button-rounded p-button-info w-full font-semibold"
+          ></a>
+        </p-card>
+      </div>
+    </main>
   </div>
 </div>


### PR DESCRIPTION
### ✨ Buyer & Seller Request Management Enhancements
### 👤 Buyer Side (Profile Section)

-         Added a dedicated Requests section in the buyer's profile to view all service requests.
-         Implemented search and filtering by service name, status, etc.

**Buyers can now:**

-          ✅ Accept/Reject seller offers.
-          ❌ Cancel pending requests.
-          🔄 Propose updates (quantity, notes) and track update status.

### 🧑‍💼 Seller Side (Service Details Page)
    Introduced a modern, searchable, and filterable requests table per service.

**Sellers can:**

        💬 Set/Update offers with guidance and attempt limits.

        🔄 Change request status with state-based restrictions.

        ✅ Accept/Reject buyer updates via modal.

        📝 View full request descriptions in modals to keep UI clean.
### 
💡 General UI/UX Improvements

    🔄 Instant UI refresh after all actions (offers, updates, status changes).

    🎨 Consistent color palette, badges, and responsive design.

    🧭 Enhanced usability with tooltips, icons, and accessible controls.